### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/django-example.js
+++ b/django-example.js
@@ -1,6 +1,8 @@
-var Django = require("github.com/quilt/django")
-var HaProxy = require("github.com/quilt/haproxy").Haproxy;
-var Mongo = require("github.com/quilt/mongo");
+const {createDeployment, Machine} = require("@quilt/quilt");
+
+var Django = require("./django.js")
+var HaProxy = require("@quilt/haproxy").Haproxy;
+var Mongo = require("@quilt/mongo");
 
 // Infrastructure
 var deployment = createDeployment({});

--- a/django.js
+++ b/django.js
@@ -1,3 +1,5 @@
+const {Container, Service} = require("@quilt/quilt");
+
 // Specs for Django web service
 function Django(cfg, mongo) {
   if (typeof cfg.nWorker !== 'number') {

--- a/package.json
+++ b/package.json
@@ -1,3 +1,11 @@
 {
-    "main": "./django.js"
+  "name": "@quilt/django",
+  "version": "0.0.1",
+  "main": "./django.js",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt",
+    "@quilt/mongo": "quilt/mongo",
+    "@quilt/haproxy": "quilt/haproxy"
+  }
 }


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.