### PR TITLE
New HAProxy constructor and other tweaks

### DIFF
--- a/django-example.js
+++ b/django-example.js
@@ -15,10 +15,9 @@ var baseMachine = new Machine({
 // Applications
 var mongo = new Mongo(3);
 
-var django = new Django({
-  nWorker: 3,
-  image: "quilt/django-polls",
-}, mongo);
+// Three Django replicas created from the "quilt/django-polls" image, and
+// connected to the mongo database.
+var django = new Django(3, "quilt/django-polls", mongo);
 
 var proxy = haproxy.singleServiceLoadBalancer(1, django._app);
 

--- a/django-example.js
+++ b/django-example.js
@@ -1,7 +1,7 @@
-const {createDeployment, Machine} = require("@quilt/quilt");
+const {createDeployment, Machine, publicInternet} = require("@quilt/quilt");
 
 var Django = require("./django.js")
-var HaProxy = require("@quilt/haproxy");
+var haproxy = require("@quilt/haproxy");
 var Mongo = require("@quilt/mongo");
 
 // Infrastructure
@@ -20,12 +20,12 @@ var django = new Django({
   image: "quilt/django-polls",
 }, mongo);
 
-var haproxy = new HaProxy(1, django.services());
+var proxy = haproxy.singleServiceLoadBalancer(1, django._app);
 
 // Connections
-haproxy.public();
+proxy.allowFrom(publicInternet, 80);
 
 // Deployment
 deployment.deploy(baseMachine.asMaster())
 deployment.deploy(baseMachine.asWorker().replicate(3))
-deployment.deploy([django, mongo, haproxy]);
+deployment.deploy([django, mongo, proxy]);

--- a/django-example.js
+++ b/django-example.js
@@ -1,30 +1,30 @@
 const {createDeployment, Machine, publicInternet} = require("@quilt/quilt");
 
-var Django = require("./django.js")
-var haproxy = require("@quilt/haproxy");
-var Mongo = require("@quilt/mongo");
+let Django = require('./django.js');
+let haproxy = require('@quilt/haproxy');
+let Mongo = require('@quilt/mongo');
 
 // Infrastructure
-var deployment = createDeployment({});
+let deployment = createDeployment({});
 
-var baseMachine = new Machine({
-  provider: "Amazon",
+let baseMachine = new Machine({
+  provider: 'Amazon',
   // sshKeys: githubKeys("CHANGE_ME"), // Replace with your GitHub username
 });
 
 // Applications
-var mongo = new Mongo(3);
+let mongo = new Mongo(3);
 
 // Three Django replicas created from the "quilt/django-polls" image, and
 // connected to the mongo database.
-var django = new Django(3, "quilt/django-polls", mongo);
+let django = new Django(3, 'quilt/django-polls', mongo);
 
-var proxy = haproxy.singleServiceLoadBalancer(1, django._app);
+let proxy = haproxy.singleServiceLoadBalancer(1, django._app);
 
 // Connections
 proxy.allowFrom(publicInternet, 80);
 
 // Deployment
-deployment.deploy(baseMachine.asMaster())
-deployment.deploy(baseMachine.asWorker().replicate(3))
+deployment.deploy(baseMachine.asMaster());
+deployment.deploy(baseMachine.asWorker().replicate(3));
 deployment.deploy([django, mongo, proxy]);

--- a/django.js
+++ b/django.js
@@ -1,11 +1,18 @@
-const {Container, Service} = require("@quilt/quilt");
+const {Container, Service} = require('@quilt/quilt');
 
-// Specs for Django web service
+/**
+ * Creates a replicated Django web service connected to MongoDB.
+ * @param {number} nWorker - The desired number of Django replicas.
+ * @param {string} image - The image for the Django application.
+ * @param {Service} mongo - The MongoDB service to connect Django to.
+ * @param {Object} [env] - The environment variables to set in the Django
+ *    containers. A map from variable name to value.
+ */
 function Django(nWorker, image, mongo, env = {}) {
-  env.MONGO_URI = mongo.uri("django-example")
+  env.MONGO_URI = mongo.uri('django-example');
 
-  var containers = new Container(image).withEnv(env).replicate(nWorker);
-  this._app = new Service("app", containers);
+  let containers = new Container(image).withEnv(env).replicate(nWorker);
+  this._app = new Service('app', containers);
 
   this.connect(mongo.port, mongo);
 };
@@ -19,7 +26,7 @@ Django.prototype.services = function() {
 };
 
 Django.prototype.connect = function(port, to) {
-  var self = this;
+  let self = this;
   to.services().forEach(function(service) {
     self._app.connect(port, service);
   });

--- a/django.js
+++ b/django.js
@@ -1,17 +1,17 @@
 const {Container, Service} = require("@quilt/quilt");
 
 // Specs for Django web service
-function Django(cfg, mongo) {
-  if (typeof cfg.nWorker !== 'number') {
+function Django(nWorker, image, mongo, env = {}) {
+  if (typeof nWorker !== 'number') {
     throw new Error('`nWorker` is required');
   }
-  if (typeof cfg.image !== 'string') {
+  if (typeof image !== 'string') {
     throw new Error('`image` is required');
   }
-  var env = cfg.env || {};
+
   env.MONGO_URI = mongo.uri("django-example")
 
-  var containers = new Container(cfg.image).withEnv(env).replicate(cfg.nWorker);
+  var containers = new Container(image).withEnv(env).replicate(nWorker);
   this._app = new Service("app", containers);
 
   mongo.connect(mongo.port, this);

--- a/django.js
+++ b/django.js
@@ -2,13 +2,6 @@ const {Container, Service} = require("@quilt/quilt");
 
 // Specs for Django web service
 function Django(nWorker, image, mongo, env = {}) {
-  if (typeof nWorker !== 'number') {
-    throw new Error('`nWorker` is required');
-  }
-  if (typeof image !== 'string') {
-    throw new Error('`image` is required');
-  }
-
   env.MONGO_URI = mongo.uri("django-example")
 
   var containers = new Container(image).withEnv(env).replicate(nWorker);

--- a/django.js
+++ b/django.js
@@ -8,7 +8,6 @@ function Django(cfg, mongo) {
   if (typeof cfg.image !== 'string') {
     throw new Error('`image` is required');
   }
-  this._port = cfg.port || 80;
   var env = cfg.env || {};
   env.MONGO_URI = mongo.uri("django-example")
 
@@ -25,10 +24,6 @@ Django.prototype.deploy = function(deployment) {
 
 Django.prototype.services = function() {
   return [this._app];
-};
-
-Django.prototype.port = function() {
-  return this._port;
 };
 
 Django.prototype.connect = function(port, to) {

--- a/django.js
+++ b/django.js
@@ -14,7 +14,6 @@ function Django(nWorker, image, mongo, env = {}) {
   var containers = new Container(image).withEnv(env).replicate(nWorker);
   this._app = new Service("app", containers);
 
-  mongo.connect(mongo.port, this);
   this.connect(mongo.port, mongo);
 };
 


### PR DESCRIPTION
It is not clear that Django should have its own blueprint. It seems like a good separate example to just create the Django container and connect it to a Mongo service without all of the boilerplate.