### PR TITLE
blueprint: Use new Mongo and HaProxy API

### DIFF
--- a/django-example.js
+++ b/django-example.js
@@ -19,7 +19,7 @@ const mongo = new Mongo(3);
 // connected to the mongo database.
 const django = new Django(3, 'quilt/django-polls', mongo);
 
-const proxy = haproxy.singleServiceLoadBalancer(1, django.app);
+const proxy = haproxy.simpleLoadBalancer(django.cluster);
 
 // Connections
 proxy.allowFrom(publicInternet, 80);

--- a/django.js
+++ b/django.js
@@ -1,29 +1,25 @@
-const { Container, Service } = require('@quilt/quilt');
+const { Container } = require('@quilt/quilt');
 
 /**
  * Creates a replicated Django web service connected to MongoDB.
  * @param {number} nWorker - The desired number of Django replicas.
  * @param {string} image - The image for the Django application.
- * @param {Service} mongo - The MongoDB service to connect Django to.
+ * @param {Mongo} mongo - The MongoDB service to connect Django to.
  * @param {Object} [env] - The environment variables to set in the Django
  *    containers. A map from variable name to value.
  */
-function Django(nWorker, image, mongo, envArg = {}) {
-  const env = envArg;
-  env.MONGO_URI = mongo.uri('django-example');
+function Django(nWorker, image, mongo, env = {}) {
+  const envWithMongo = { MONGO_URI: mongo.uri('django-example') };
+  Object.assign(envWithMongo, env);
 
-  const containers = new Container(image).withEnv(env).replicate(nWorker);
-  this.app = new Service('app', containers);
-
-  mongo.allowFrom(this, mongo.port);
+  this.cluster = new Container('django-poll', image)
+    .withEnv(envWithMongo)
+    .replicate(nWorker);
+  mongo.allowFrom(this.cluster, mongo.port);
 }
 
 Django.prototype.deploy = function deploy(deployment) {
-  deployment.deploy(this.services());
-};
-
-Django.prototype.services = function services() {
-  return [this.app];
+  deployment.deploy(this.cluster);
 };
 
 module.exports = Django;


### PR DESCRIPTION
The Mongo and HaProxy APIs changed because the Quilt API now deploys
containers directly.